### PR TITLE
Fix #15?

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 org.gradle.jvmargs=-Xmx1G
 
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.12
-loader_version=0.12.12
-fabric_version=0.45.0+1.18
-clothconfig_version=6.1.48
-modmenu_version=3.0.1
+minecraft_version=1.18.2
+yarn_mappings=1.18.2+build.3
+loader_version=0.14.4
+fabric_version=0.51.1+1.18.2
+clothconfig_version=6.2.57
+modmenu_version=3.2.1
 
 mod_version = 1.4.1
 maven_group = net.ludocrypt

--- a/src/main/java/net/ludocrypt/dynmus/mixin/MinecraftClientMixin.java
+++ b/src/main/java/net/ludocrypt/dynmus/mixin/MinecraftClientMixin.java
@@ -35,9 +35,9 @@ public class MinecraftClientMixin {
 			if (this.world != null) {
 				if (DynamicMusic.isInCave(world, player.getBlockPos())) {
 					dynmus$setReturnType(ci, DynamicMusic.MUSIC_CAVE);
-				} else if ((world.getBiomeAccess().getBiome(this.player.getBlockPos()).getTemperature() < 0.15F) || (world.isRaining()) && DynamicMusicConfig.getInstance().coldMusic) {
+				} else if ((world.getBiomeAccess().getBiome(this.player.getBlockPos()).value().getTemperature() < 0.15F) || (world.isRaining()) && DynamicMusicConfig.getInstance().coldMusic) {
 					dynmus$setReturnType(ci, DynamicMusic.MUSIC_COLD);
-				} else if ((world.getBiomeAccess().getBiome(this.player.getBlockPos()).getTemperature() > 0.95F) && (!world.isRaining()) && DynamicMusicConfig.getInstance().hotMusic) {
+				} else if ((world.getBiomeAccess().getBiome(this.player.getBlockPos()).value().getTemperature() > 0.95F) && (!world.isRaining()) && DynamicMusicConfig.getInstance().hotMusic) {
 					dynmus$setReturnType(ci, DynamicMusic.MUSIC_HOT);
 				} else if (world.getTimeOfDay() <= 12500 && DynamicMusicConfig.getInstance().niceMusic) {
 					dynmus$setReturnType(ci, DynamicMusic.MUSIC_NICE);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,6 +29,6 @@
 	"depends": {
 		"fabricloader": ">=0.7.4",
 		"fabric": "*",
-		"minecraft": "1.18.x"
+		"minecraft": "1.18.2"
 	}
 }


### PR DESCRIPTION
**Disclaimer:** These changes are not *yet* tested.
#15 crash log mentioned a missing method `Biome BiomeAccess::getBiome(BlockPos)`. Upon further inspection, this is likely caused by a change to the return type to `RegistryEntry<Biome>` in 1.18.2